### PR TITLE
#616

### DIFF
--- a/grails-app/assets/javascripts/spApp/controller/areaReportCtrl.js
+++ b/grails-app/assets/javascripts/spApp/controller/areaReportCtrl.js
@@ -307,7 +307,7 @@
                         });
 
                         $.each(['Algae', 'Amphibians', 'Angiosperms', 'Animals', 'Arthropods', 'Bacteria', 'Birds',
-                            'Bryophytes', 'Chromista', 'Crustaceans', 'Dicots', 'FernsAndAllies', 'Fishes', 'Fungi',
+                            'Bryophytes', 'Chromista', 'Crustaceans', 'Dicots', 'fernsAndAllies', 'Fish', 'Former Fishes', 'Fungi',
                             'Gymnosperms', 'Insects', 'Mammals', 'Molluscs', 'Monocots', 'Plants', 'Protozoa', 'Reptiles'], function (i, v) {
                             $scope.items.push({
                                 name: v,


### PR DESCRIPTION
- quick and dirty fix: update hardcoded list of lifeform groups according to our vbp config (groups.json). Ideally the list should not be hardcoded but queried from the index.